### PR TITLE
Streamline preprocessor guards against multiple inclusion

### DIFF
--- a/src/Core.h
+++ b/src/Core.h
@@ -1,5 +1,5 @@
-#ifndef _CORE_H
-#define _CORE_H
+#ifndef CORE_H
+#define CORE_H
 
 #include "Core/Animation.h"
 #include "Core/Input.h"
@@ -8,5 +8,5 @@
 #include "Core/Utils.h"
 #include "Core/Window.h"
 
-#endif // _CORE_H
+#endif // CORE_H
 

--- a/src/Core/Animation.h
+++ b/src/Core/Animation.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef ANIMATION_H_INCLUDED
-#define ANIMATION_H_INCLUDED
+#ifndef ANIMATION_H
+#define ANIMATION_H
 
 
 //struct Animation
@@ -60,4 +60,4 @@ public:
 };
 
 
-#endif // ANIMATION_H_INCLUDED
+#endif // ANIMATION_H

--- a/src/Core/Input.h
+++ b/src/Core/Input.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _INPUT_H
-#define _INPUT_H
+#ifndef INPUT_H
+#define INPUT_H
 
 #include <iostream>
 #include <SFML/Graphics.hpp>
@@ -57,4 +57,4 @@ public:
 	static sf::String GetEnteredText();
 };
 
-#endif // _INPUT_H
+#endif // INPUT_H

--- a/src/Core/Random.h
+++ b/src/Core/Random.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _RANDOM_H
-#define _RANDOM_H
+#ifndef RANDOM_H
+#define RANDOM_H
 
 #include <iostream>
 
@@ -31,4 +31,4 @@ public:
 
 };
 
-#endif // _RANDOM_H
+#endif // RANDOM_H

--- a/src/Core/Utils.h
+++ b/src/Core/Utils.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _UTILS_H
-#define _UTILS_H
+#ifndef UTILS_H
+#define UTILS_H
 
 #include <iostream>
 #include <fstream>
@@ -48,4 +48,4 @@ void DFT(const vector<double>& in, vector<double>& out);
 sf::Color fromHSV(float h, float s, float v);
 sf::Color lerp(const sf::Color& a, const sf::Color& b, float t);
 
-#endif // _UTILS_H
+#endif // UTILS_H

--- a/src/Core/Window.h
+++ b/src/Core/Window.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _WINDOW_H
-#define _WINDOW_H
+#ifndef WINDOW_H
+#define WINDOW_H
 
 #include <iostream>
 #include <SFML/Graphics.hpp>
@@ -59,4 +59,4 @@ public:
 	static sf::RenderWindow* GetWindow();
 };
 
-#endif // _WINDOW_H
+#endif // WINDOW_H

--- a/src/FreqView.h
+++ b/src/FreqView.h
@@ -1,5 +1,5 @@
-#ifndef _FREQVIEW_H
-#define _FREQVIEW_H
+#ifndef FREQVIEW_H
+#define FREQVIEW_H
 
 #include "UI/AbstractUI.h"
 #include <vector>
@@ -27,4 +27,4 @@ private:
 	sf::Color m_color;
 };
 
-#endif // _FREQVIEW_H
+#endif // FREQVIEW_H

--- a/src/Math/Matrix3.h
+++ b/src/Math/Matrix3.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _MATRIX3_H
-#define _MATRIX3_H
+#ifndef MATRIX3_H
+#define MATRIX3_H
 
 #include <iostream>
 #include "Vector3.h"
@@ -73,4 +73,4 @@ Matrix3 operator*(float _f, const Matrix3& _m);
 Matrix3 operator*(const Matrix3& _m, float _f);
 Matrix3 operator/(const Matrix3& _m, float _f);
 
-#endif // _MATRIX3_H
+#endif // MATRIX3_H

--- a/src/Math/Matrix4.h
+++ b/src/Math/Matrix4.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _MATRIX4_H
-#define _MATRIX4_H
+#ifndef MATRIX4_H
+#define MATRIX4_H
 
 #include <iostream>
 
@@ -28,4 +28,4 @@ public:
 
 };
 
-#endif // _MATRIX4_H
+#endif // MATRIX4_H

--- a/src/Math/Vector2.h
+++ b/src/Math/Vector2.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _VECTOR2_H
-#define _VECTOR2_H
+#ifndef VECTOR2_H
+#define VECTOR2_H
 
 #include <SFML/System.hpp>
 #include <iostream>
@@ -69,4 +69,4 @@ Vector2 operator*(const Vector2& _a, float _b);
 Vector2 operator/(const Vector2& _a, float _b);
 
 
-#endif // _VECTOR2_H
+#endif // VECTOR2_H

--- a/src/Math/Vector3.h
+++ b/src/Math/Vector3.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _VECTOR3_H
-#define _VECTOR3_H
+#ifndef VECTOR3_H
+#define VECTOR3_H
 
 #include <iostream>
 
@@ -65,4 +65,4 @@ Vector3 operator*(float _a, const Vector3& _b);
 Vector3 operator*(const Vector3& _a, float _b);
 Vector3 operator/(const Vector3& _a, float _b);
 
-#endif // _VECTOR3_H
+#endif // VECTOR3_H

--- a/src/OsciView.h
+++ b/src/OsciView.h
@@ -1,5 +1,5 @@
-#ifndef _OSCIVIEW_H
-#define _OSCIVIEW_H
+#ifndef OSCIVIEW_H
+#define OSCIVIEW_H
 
 #include "UI/AbstractUI.h"
 #include <vector>
@@ -34,4 +34,4 @@ private:
 	float m_lineWidth = 6.0f;
 };
 
-#endif // _OSCIVIEW_H
+#endif // OSCIVIEW_H

--- a/src/SpectrumView.h
+++ b/src/SpectrumView.h
@@ -1,5 +1,5 @@
-#ifndef _SPECTRUMVIEW_H
-#define _SPECTRUMVIEW_H
+#ifndef SPECTRUMVIEW_H
+#define SPECTRUMVIEW_H
 
 #include "UI/AbstractUI.h"
 #include <vector>
@@ -31,4 +31,4 @@ private:
 	size_t m_currentIndex;
 };
 
-#endif // _SPECTRUMVIEW_H
+#endif // SPECTRUMVIEW_H

--- a/src/StereoRecorder.h
+++ b/src/StereoRecorder.h
@@ -1,5 +1,5 @@
-#ifndef _STEREORECORDER_H
-#define _STEREORECORDER_H
+#ifndef STEREORECORDER_H
+#define STEREORECORDER_H
 
 #include <SFML/Audio/SoundRecorder.hpp>
 #include <vector>
@@ -42,4 +42,4 @@ private:
 	bool m_DFTEnabled;
 };
 
-#endif // _STEREORECORDER_H
+#endif // STEREORECORDER_H

--- a/src/UI.h
+++ b/src/UI.h
@@ -1,5 +1,5 @@
-#ifndef _UI_H
-#define _UI_H
+#ifndef UI_H
+#define UI_H
 
 #include "UI/AbstractUI.h"
 #include "UI/AbstractSlider.h"
@@ -18,5 +18,5 @@
 #include "UI/VerticalLayout.h"
 #include "UI/View.h"
 
-#endif // _UI_H
+#endif // UI_H
 

--- a/src/UI/AbstractSlider.h
+++ b/src/UI/AbstractSlider.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _ABSTRACTSLIDER_H
-#define _ABSTRACTSLIDER_H
+#ifndef ABSTRACTSLIDER_H
+#define ABSTRACTSLIDER_H
 
 #include <iostream>
 #include "AbstractUI.h"
@@ -45,4 +45,4 @@ private:
 	bool m_valueChanged;
 };
 
-#endif // _ABSTRACTSLIDER_H
+#endif // ABSTRACTSLIDER_H

--- a/src/UI/AbstractUI.h
+++ b/src/UI/AbstractUI.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _ABSTRACTUI_H
-#define _ABSTRACTUI_H
+#ifndef ABSTRACTUI_H
+#define ABSTRACTUI_H
 
 #include <iostream>
 #include <SFML/Graphics.hpp>
@@ -107,4 +107,4 @@ protected:
 	Stretch m_stretch;
 };
 
-#endif // _ABSTRACTUI_H
+#endif // ABSTRACTUI_H

--- a/src/UI/Button.h
+++ b/src/UI/Button.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef BUTTON_H_INCLUDED
-#define BUTTON_H_INCLUDED
+#ifndef BUTTON_H
+#define BUTTON_H
 
 
 #include <SFML/Graphics.hpp>
@@ -53,4 +53,4 @@ protected:
 };
 
 
-#endif // BUTTON_H_INCLUDED
+#endif // BUTTON_H

--- a/src/UI/DialButton.h
+++ b/src/UI/DialButton.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _DIALBUTTON_H
-#define _DIALBUTTON_H
+#ifndef DIALBUTTON_H
+#define DIALBUTTON_H
 
 #include <iostream>
 #include "AbstractSlider.h"
@@ -60,4 +60,4 @@ private:
 	LabelPosition m_labelPosition;
 };
 
-#endif // _DIALBUTTON_H
+#endif // DIALBUTTON_H

--- a/src/UI/DraggableBox.h
+++ b/src/UI/DraggableBox.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _DRAGGABLEBOX_H
-#define _DRAGGABLEBOX_H
+#ifndef DRAGGABLEBOX_H
+#define DRAGGABLEBOX_H
 
 #include <iostream>
 #include "AbstractUI.h"
@@ -41,4 +41,4 @@ protected:
 	//virtual void _updateStyle() override;
 };
 
-#endif // _DRAGGABLEBOX_H
+#endif // DRAGGABLEBOX_H

--- a/src/UI/HorizontalLayout.h
+++ b/src/UI/HorizontalLayout.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _HORIZONTALLAYOUT_H
-#define _HORIZONTALLAYOUT_H
+#ifndef HORIZONTALLAYOUT_H
+#define HORIZONTALLAYOUT_H
 
 #include <iostream>
 #include "Layout.h"
@@ -37,4 +37,4 @@ public:
 	virtual void update() override;
 };
 
-#endif // _HORIZONTALLAYOUT_H
+#endif // HORIZONTALLAYOUT_H

--- a/src/UI/IconButton.h
+++ b/src/UI/IconButton.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _ICONBUTTON_H
-#define _ICONBUTTON_H
+#ifndef ICONBUTTON_H
+#define ICONBUTTON_H
 
 
 #include <SFML/Graphics.hpp>
@@ -41,4 +41,4 @@ protected:
 };
 
 
-#endif // _ICONBUTTON_H
+#endif // ICONBUTTON_H

--- a/src/UI/InputField.h
+++ b/src/UI/InputField.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _INPUTFIELD_H
-#define _INPUTFIELD_H
+#ifndef INPUTFIELD_H
+#define INPUTFIELD_H
 
 #include <iostream>
 #include <SFML/Graphics.hpp>
@@ -64,4 +64,4 @@ protected:
 	virtual void _updateStyle() override;
 };
 
-#endif // _INPUTFIELD_H
+#endif // INPUTFIELD_H

--- a/src/UI/Label.h
+++ b/src/UI/Label.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _LABEL_H
-#define _LABEL_H
+#ifndef LABEL_H
+#define LABEL_H
 
 #include <SFML/Graphics.hpp>
 #include "AbstractUI.h"
@@ -54,4 +54,4 @@ protected:
 
 };
 
-#endif // _LABEL_H
+#endif // LABEL_H

--- a/src/UI/Layout.h
+++ b/src/UI/Layout.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _LAYOUT_H
-#define _LAYOUT_H
+#ifndef LAYOUT_H
+#define LAYOUT_H
 
 #include <iostream>
 #include "AbstractUI.h"
@@ -38,4 +38,4 @@ protected:
 	virtual void draw(sf::RenderTarget &target, sf::RenderStates states) const;
 };
 
-#endif // _LAYOUT_H
+#endif // LAYOUT_H

--- a/src/UI/Scrollbar.h
+++ b/src/UI/Scrollbar.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _SCROLLBAR_H
-#define _SCROLLBAR_H
+#ifndef SCROLLBAR_H
+#define SCROLLBAR_H
 
 #include <iostream>
 #include "AbstractSlider.h"
@@ -41,4 +41,4 @@ private:
 	bool m_dragging;
 };
 
-#endif // _SCROLLBAR_H
+#endif // SCROLLBAR_H

--- a/src/UI/Toggle.h
+++ b/src/UI/Toggle.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _TOGGLE_H
-#define _TOGGLE_H
+#ifndef TOGGLE_H
+#define TOGGLE_H
 
 #include <iostream>
 #include "Button.h"
@@ -37,4 +37,4 @@ protected:
 	virtual void _updateStyle() override;*/
 };
 
-#endif // _TOGGLE_H
+#endif // TOGGLE_H

--- a/src/UI/UIManager.h
+++ b/src/UI/UIManager.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _UIMANAGER_H
-#define _UIMANAGER_H
+#ifndef UIMANAGER_H
+#define UIMANAGER_H
 
 #include <vector>
 #include "AbstractUI.h"
@@ -63,4 +63,4 @@ public:
 
 };
 
-#endif // _UIMANAGER_H
+#endif // UIMANAGER_H

--- a/src/UI/UIStyle.h
+++ b/src/UI/UIStyle.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _UISTYLE_H
-#define _UISTYLE_H
+#ifndef UISTYLE_H
+#define UISTYLE_H
 
 #include <iostream>
 #include <SFML/Graphics.hpp>
@@ -50,4 +50,4 @@ public:
 	static UIStyle Default;
 };
 
-#endif // _UISTYLE_H
+#endif // UISTYLE_H

--- a/src/UI/VerticalLayout.h
+++ b/src/UI/VerticalLayout.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _VERTICALLAYOUT_H
-#define _VERTICALLAYOUT_H
+#ifndef VERTICALLAYOUT_H
+#define VERTICALLAYOUT_H
 
 #include <iostream>
 #include "Layout.h"
@@ -37,4 +37,4 @@ public:
 	virtual void update() override;
 };
 
-#endif // _VERTICALLAYOUT_H
+#endif // VERTICALLAYOUT_H

--- a/src/UI/View.h
+++ b/src/UI/View.h
@@ -9,8 +9,8 @@
 *
 */
 
-#ifndef _VIEW_H
-#define _VIEW_H
+#ifndef VIEW_H
+#define VIEW_H
 
 #include <iostream>
 #include "SFML/Graphics.hpp"
@@ -51,4 +51,4 @@ protected:
 	virtual void draw(sf::RenderTarget &target, sf::RenderStates states) const;
 };
 
-#endif // _VIEW_H
+#endif // VIEW_H

--- a/src/WaveView.h
+++ b/src/WaveView.h
@@ -1,5 +1,5 @@
-#ifndef _WAVEVIEW_H
-#define _WAVEVIEW_H
+#ifndef WAVEVIEW_H
+#define WAVEVIEW_H
 
 #include "UI/AbstractUI.h"
 #include <vector>
@@ -31,4 +31,4 @@ private:
 	int m_sampleRate = 0;
 };
 
-#endif // _WAVEVIEW_H
+#endif // WAVEVIEW_H


### PR DESCRIPTION
100% done with:
```console
$ for i in $(find -name \*.h); do h="$(basename "$i")"; h="${h^^}"; h="${h/./_}"; sed -e "s,_${h},${h}," -e "s,${h}_INCLUDED,${h}," -i "${i}" ; done
```